### PR TITLE
Wrap object option

### DIFF
--- a/knockout.mapper.js
+++ b/knockout.mapper.js
@@ -16,6 +16,11 @@
         return running != 0;
     };
 
+    // Set default options here that will be merged to
+    // every fromJS or toJS call.
+    exports.defaultOptions = {
+    };
+
     exports.fromJSContext = function(parents, options) {
         this.parents = parents || [];
         this.options = options;
@@ -47,13 +52,17 @@
             options = options.$fromJS;
 
         if (options) {
-            if (options.$handler) {
-                handler = options.$handler.fromJS || options.$handler;
-            } else if (getType(options) == "string") {
+            if (getType(options) == "string") {
                 handler = options;
+                options = exports.defaultOptions || {};
+            } else {
+                options = exports.mergeOptions(exports.defaultOptions, options);
+                if (options.$handler) {
+                    handler = options.$handler.fromJS || options.$handler;
+                }
             }
         } else {
-            options = {};
+            options = exports.defaultOptions || {};
         }
 
         var result = null;
@@ -79,13 +88,17 @@
             options = options.$toJS;
 
         if (options) {
-            if (options.$handler) {
-                handler = options.$handler.toJS || options.$handler;
-            } else if (getType(options) == "string") {
+            if (getType(options) == "string") {
                 handler = options;
+                options = exports.defaultOptions || {};
+            } else {
+                options = exports.mergeOptions(exports.defaultOptions, options);
+                if (options.$handler) {
+                    handler = options.$handler.toJS || options.$handler;
+                }
             }
         } else {
-            options = {};
+            options = exports.defaultOptions || {};
         }
 
         var result = null;

--- a/knockout.mapper.js
+++ b/knockout.mapper.js
@@ -287,7 +287,7 @@
                     target(obj);
 
                 return target;
-            } else if (wrap) {
+            } else if (wrap && (options.$wrapObject === undefined || options.$wrapObject === true)) {
                 return ko.observable(obj);
             } else {
                 return obj;


### PR DESCRIPTION
knockout.mapping only creates observables for the values while knockout.mapper does also create observables for objects. To keep compatibility with knockout.mapping I've added a new option '$wrapObject' that can be set to false to emulate knockout.mapping behaviour (enabled by default).

Also, I've added a new export 'defaultOptions' that contains an object whose values will be merged to the 'options' of every toJS and fromJS call. This allows to disable $wrapObject globally.