### PR TITLE
New option: $ignoreNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,15 @@ var mapping = {
 };
 ```
 
+Dynamically ignore a member in toJS:
+```JS
+var mapping = {
+  '$ignoreNode': function(value, parent, index) {
+    // Ignore a member when it has a '_ignore_member' property
+    return value === undefined || !value._ignore_member;
+  }
+}
+
 ##LICENSE
 Licensed under the MIT License.  
 http://opensource.org/licenses/mit-license.php

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ var mapping = {
     return value === undefined || !value._ignore_member;
   }
 }
+```
 
 ##LICENSE
 Licensed under the MIT License.  

--- a/knockout.mapper.js
+++ b/knockout.mapper.js
@@ -246,6 +246,10 @@
             var value = ko.utils.unwrapObservable(observable);
             var arr = [];
             for (var i = 0; i < value.length; i++) {
+                if (options.$ignoreNode !== undefined && options.$ignoreNode(value[i], value, i)) {
+                    continue;
+                }
+
                 var itemOptions = options.$itemOptions;
                 if (typeof itemOptions == 'function') itemOptions = itemOptions(observable, options);
 
@@ -295,6 +299,10 @@
             var value = ko.utils.unwrapObservable(observable);
             var obj = {};
             for (var p in value) {
+                if (options.$ignoreNode !== undefined && options.$ignoreNode(value[p], value, p)) {
+                    continue;
+                }
+
                 var val = exports.toJS(value[p], options[p] || options.$default);
                 if (val !== exports.ignore) {
                     obj[p] = val;


### PR DESCRIPTION
This patch introduces a new option called '$ignoreNode' that
can be used as a callback function to dynamically exclude nodes
on 'toJS'/'toJSON' calls.

Signed-off-by: Roland Tapken <roland@bitarbeiter.net>